### PR TITLE
Add support for objects and arrays to `is.equal()`

### DIFF
--- a/is.js
+++ b/is.js
@@ -221,8 +221,8 @@
     // Arithmetic checks
     /* -------------------------------------------------------------------------- */
 
-    // are given values equal? supports numbers, strings, regexps, booleans
-    // TODO: Add object and array support
+    // are given values equal?
+    // supports numbers, strings, regexps, booleans, objects, arrays
     is.equal = function(value1, value2) {
         // check 0 and -0 equity with Infinity and -Infinity
         if(is.all.number(value1, value2)) {
@@ -234,6 +234,9 @@
         }
         if(is.all.boolean(value1, value2)) {
             return value1 === value2;
+        }
+        if(is.all.object(value1, value2) || is.all.array(value1, value2)) {
+            return JSON.stringify(value1) === JSON.stringify(value2);
         }
         return false;
     };

--- a/is.js
+++ b/is.js
@@ -230,7 +230,7 @@
         }
         // check regexps as strings too
         if(is.all.string(value1, value2) || is.all.regexp(value1, value2)) {
-            return '' + value1 === '' + value2;
+            return value1.toString() === value2.toString();
         }
         if(is.all.boolean(value1, value2)) {
             return value1 === value2;


### PR DESCRIPTION
Add support for both arrays and objects to `is.equal()` by comparing the JSON.stringified result of both values.