### PR TITLE
Contextual regexp features

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,32 @@ is.all.affirmative(['yes', 'y', 'true', 't', 'ok', 'okay']);
 => true
 ```
 
+is.fr.affirmative(value:any)
+-------------------------
+####Checks if the given value matches affirmative in french regexp.
+interfaces: not, all, any
+
+```javascript
+is.fr.affirmative('oui');
+=> true
+
+is.fr.affirmative('non');
+=> false
+
+is.not.fr.affirmative('non');
+=> true
+
+is.all.fr.affirmative('oui', 'non');
+=> false
+
+is.any.fr.affirmative('oui', 'non');
+=> true
+
+// 'all' and 'any' interfaces can also take array parameter
+is.all.fr.affirmative(['oui', 'o', 'vrai', 'v', 'ok', 'okay']);
+=> true
+```
+
 is.hexadecimal(value:any)
 -------------------------
 ####Checks if the given value matches hexadecimal regexp.

--- a/README.md
+++ b/README.md
@@ -650,81 +650,107 @@ is.all.dateString(['11/11/2011', '90/11/2011']);
 => false
 ```
 
-is.usZipCode(value:any)
+is.us.postalCode(value:any)
 -----------------------
 ####Checks if the given value matches US zip code regexp.
 interfaces: not, all, any
 
 ```javascript
-is.usZipCode('02201-1020');
+is.us.postalCode('02201-1020');
 => true
 
-is.usZipCode('123');
+is.us.postalCode('123');
 => false
 
-is.not.usZipCode('123');
+is.not.us.postalCode('123');
 => true
 
-is.all.usZipCode('02201-1020', '123');
+is.all.us.postalCode('02201-1020', '123');
 => false
 
-is.any.usZipCode('02201-1020', '123');
+is.any.us.postalCode('02201-1020', '123');
 => true
 
 // 'all' and 'any' interfaces can also take array parameter
-is.all.usZipCode(['02201-1020', '123']);
+is.all.us.postalCode(['02201-1020', '123']);
 => false
 ```
 
-is.caPostalCode(value:any)
+is.ca.postalCode(value:any)
 --------------------------
 ####Checks if the given value matches Canada postal code regexp.
 interfaces: not, all, any
 
 ```javascript
-is.caPostalCode('L8V3Y1');
+is.ca.postalCode('L8V3Y1');
 => true
 
-is.caPostalCode('123');
+is.ca.postalCode('123');
 => false
 
-is.not.caPostalCode('123');
+is.not.ca.postalCode('123');
 => true
 
-is.all.caPostalCode('L8V3Y1', '123');
+is.all.ca.postalCode('L8V3Y1', '123');
 => false
 
-is.any.caPostalCode('L8V3Y1', '123');
+is.any.ca.postalCode('L8V3Y1', '123');
 => true
 
 // 'all' and 'any' interfaces can also take array parameter
-is.all.caPostalCode(['L8V3Y1', '123']);
+is.all.ca.postalCode(['L8V3Y1', '123']);
 => false
 ```
 
-is.ukPostCode(value:any)
+is.uk.postalCode(value:any)
 ------------------------
 ####Checks if the given value matches UK post code regexp.
 interfaces: not, all, any
 
 ```javascript
-is.ukPostCode('B184BJ');
+is.uk.postalCode('B184BJ');
 => true
 
-is.ukPostCode('123');
+is.uk.postalCode('123');
 => false
 
-is.not.ukPostCode('123');
+is.not.uk.postalCode('123');
 => true
 
-is.all.ukPostCode('B184BJ', '123');
+is.all.uk.postalCode('B184BJ', '123');
 => false
 
-is.any.ukPostCode('B184BJ', '123');
+is.any.uk.postalCode('B184BJ', '123');
 => true
 
 // 'all' and 'any' interfaces can also take array parameter
-is.all.ukPostCode(['B184BJ', '123']);
+is.all.uk.postalCode(['B184BJ', '123']);
+=> false
+```
+
+is.fr.postalCode(value:any)
+------------------------
+####Checks if the given value matches FR post code regexp.
+interfaces: not, all, any
+
+```javascript
+is.fr.postalCode('44000');
+=> true
+
+is.fr.postalCode('123');
+=> false
+
+is.not.fr.postalCode('123');
+=> true
+
+is.all.fr.postalCode('44000', '123');
+=> false
+
+is.any.fr.postalCode('44000', '123');
+=> true
+
+// 'all' and 'any' interfaces can also take array parameter
+is.all.fr.postalCode(['44000', '123']);
 => false
 ```
 

--- a/is.js
+++ b/is.js
@@ -347,17 +347,27 @@
     function regexpCheckContextual(regexp, regexps) {
         for(var regexpContext in regexps[regexp]) {
             if(regexps[regexp].hasOwnProperty(regexpContext)) {
-                if(is.undefined(is[regexpContext]) && regexpContext !== "default") {
+                if(is.undefined(is[regexpContext]) && regexpContext !== "default" && regexpContext !== "always") {
                     is[regexpContext] = {};
                 }
                 if(regexpContext === "default") {
                     is[regexp] = function(value) {
-                        return regexps[regexp].default.test(value);
+                        if(regexps[regexp].hasOwnProperty("always")) {
+                            return regexps[regexp].default.test(value) || regexps[regexp].always.test(value);
+                        }
+                        else {
+                            return regexps[regexp].default.test(value);
+                        }
                     };
                 }
-                else {
+                else if(regexpContext !== "always") {
                     is[regexpContext][regexp] = function(value) {
-                        return regexps[regexp][regexpContext].test(value);
+                        if(regexps[regexp].hasOwnProperty("always")) {
+                            return regexps[regexp][regexpContext].test(value) || regexps[regexp].always.test(value);
+                        }
+                        else {
+                            return regexps[regexp][regexpContext].test(value);
+                        }
                     };
                 }
             }

--- a/is.js
+++ b/is.js
@@ -329,7 +329,12 @@
     // create regexp checks methods from 'regexp' object
     for(var regexp in regexps) {
         if(regexps.hasOwnProperty(regexp)) {
-            regexpCheck(regexp, regexps);
+            if(is.object(regexps[regexp])) {
+                regexpCheckContextual(regexp, regexps);
+            }
+            else {
+                regexpCheck(regexp, regexps);
+            }
         }
     }
 
@@ -337,6 +342,26 @@
         is[regexp] = function(value) {
             return regexps[regexp].test(value);
         };
+    }
+
+    function regexpCheckContextual(regexp) {
+        for(var regexpContext in regexps[regexp]) {
+            if(regexps[regexp].hasOwnProperty(regexpContext)) {
+                if(is.undefined(is[regexpContext]) && regexpContext !== "default") {
+                    is[regexpContext] = {};
+                }
+                if(regexpContext === "default") {
+                    is[regexp] = function(value) {
+                        return regexps[regexp].default.test(value);
+                    };
+                }
+                else {
+                    is[regexpContext][regexp] = function(value) {
+                        return regexps[regexp][regexpContext].test(value);
+                    };
+                }
+            }
+        }
     }
 
     // String checks

--- a/is.js
+++ b/is.js
@@ -349,31 +349,33 @@
 
     function regexpCheckContextual(regexp, regexps) {
         for(var regexpContext in regexps[regexp]) {
-            if(regexps[regexp].hasOwnProperty(regexpContext)) {
-                if(is.undefined(is[regexpContext]) && regexpContext !== "default" && regexpContext !== "always") {
-                    is[regexpContext] = {};
+            (function(regexpContext) {
+                if(regexps[regexp].hasOwnProperty(regexpContext)) {
+                    if(is.undefined(is[regexpContext]) && regexpContext !== "default" && regexpContext !== "always") {
+                        is[regexpContext] = {};
+                    }
+                    if(regexpContext === "default") {
+                        is[regexp] = function(value) {
+                            if(regexps[regexp].hasOwnProperty("always")) {
+                                return regexps[regexp].default.test(value) || regexps[regexp].always.test(value);
+                            }
+                            else {
+                                return regexps[regexp].default.test(value);
+                            }
+                        };
+                    }
+                    else if(regexpContext !== "always") {
+                        is[regexpContext][regexp] = function(value) {
+                            if(regexps[regexp].hasOwnProperty("always")) {
+                                return regexps[regexp][regexpContext].test(value) || regexps[regexp].always.test(value);
+                            }
+                            else {
+                                return regexps[regexp][regexpContext].test(value);
+                            }
+                        };
+                    }
                 }
-                if(regexpContext === "default") {
-                    is[regexp] = function(value) {
-                        if(regexps[regexp].hasOwnProperty("always")) {
-                            return regexps[regexp].default.test(value) || regexps[regexp].always.test(value);
-                        }
-                        else {
-                            return regexps[regexp].default.test(value);
-                        }
-                    };
-                }
-                else if(regexpContext !== "always") {
-                    is[regexpContext][regexp] = function(value) {
-                        if(regexps[regexp].hasOwnProperty("always")) {
-                            return regexps[regexp][regexpContext].test(value) || regexps[regexp].always.test(value);
-                        }
-                        else {
-                            return regexps[regexp][regexpContext].test(value);
-                        }
-                    };
-                }
-            }
+            })(regexpContext);
         }
     }
 

--- a/is.js
+++ b/is.js
@@ -807,6 +807,27 @@
                     }
                 }
             }
+            else if(is.object(options[option])) {
+                for(var contextualOption in options[option]) {
+                    if(hasOwnProperty.call(options[option], contextualOption) && is.function(options[option][contextualOption])) {
+                        var interfaces = options[option][contextualOption].api || ['not', 'all', 'any'];
+                        for (var i = 0; i < interfaces.length; i++) {
+                            if(interfaces[i] === 'not') {
+                                is.not[option] = is.not[option] || {};
+                                is.not[option][contextualOption] = not(is[option][contextualOption]);
+                            }
+                            if(interfaces[i] === 'all') {
+                                is.all[option] = is.all[option] || {};
+                                is.all[option][contextualOption] = all(is[option][contextualOption]);
+                            }
+                            if(interfaces[i] === 'any') {
+                                is.any[option] = is.any[option] || {};
+                                is.any[option][contextualOption] = any(is[option][contextualOption]);
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
     setInterfaces();

--- a/is.js
+++ b/is.js
@@ -315,15 +315,18 @@
         alphaNumeric: /^[A-Za-z0-9]+$/,
         timeString: /^(2[0-3]|[01]?[0-9]):([0-5]?[0-9]):([0-5]?[0-9])$/,
         dateString: /^(1[0-2]|0?[1-9])\/(3[01]|[12][0-9]|0?[1-9])\/(?:[0-9]{2})?[0-9]{2}$/,
-        usZipCode: /^[0-9]{5}(?:-[0-9]{4})?$/,
-        caPostalCode: /^(?!.*[DFIOQU])[A-VXY][0-9][A-Z]?[0-9][A-Z][0-9]$/,
-        ukPostCode: /^[A-Z]{1,2}[0-9RCHNQ][0-9A-Z]?\s?[0-9][ABD-HJLNP-UW-Z]{2}$|^[A-Z]{2}-?[0-9]{4}$/,
         nanpPhone: /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/,
         eppPhone: /^\+[0-9]{1,3}\.[0-9]{4,14}(?:x.+)?$/,
         socialSecurityNumber: /^(?!000|666)[0-8][0-9]{2}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}$/,
         affirmative: /^(?:1|t(?:rue)?|y(?:es)?|ok(?:ay)?)$/,
         hexadecimal: /^[0-9a-fA-F]+$/,
-        hexColor: /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
+        hexColor: /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/,
+        postalCode: {
+            us: /^[0-9]{5}(?:-[0-9]{4})?$/,
+            ca: /^(?!.*[DFIOQU])[A-VXY][0-9][A-Z]?[0-9][A-Z][0-9]$/,
+            uk: /^[A-Z]{1,2}[0-9RCHNQ][0-9A-Z]?\s?[0-9][ABD-HJLNP-UW-Z]{2}$|^[A-Z]{2}-?[0-9]{4}$/,
+            fr: /^[0-9]{5}$/
+        }
     };
 
     // create regexp checks methods from 'regexp' object

--- a/is.js
+++ b/is.js
@@ -318,7 +318,12 @@
         nanpPhone: /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/,
         eppPhone: /^\+[0-9]{1,3}\.[0-9]{4,14}(?:x.+)?$/,
         socialSecurityNumber: /^(?!000|666)[0-8][0-9]{2}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}$/,
-        affirmative: /^(?:1|t(?:rue)?|y(?:es)?|ok(?:ay)?)$/,
+        affirmative: {
+            always: /^(?:1|ok(?:ay)?)$/,
+            default: /^(t(?:rue)?|y(?:es)?)$/,
+            en: /^(t(?:rue)?|y(?:es)?)$/,
+            fr: /^(v(?:rai)?|o(?:ui)?)$/
+        },
         hexadecimal: /^[0-9a-fA-F]+$/,
         hexColor: /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/,
         postalCode: {

--- a/is.js
+++ b/is.js
@@ -332,7 +332,7 @@
     // create regexp checks methods from 'regexp' object
     for(var regexp in regexps) {
         if(regexps.hasOwnProperty(regexp)) {
-            if(is.object(regexps[regexp])) {
+            if(is.object(regexps[regexp]) && !is.regexp(regexps[regexp])) {
                 regexpCheckContextual(regexp, regexps);
             }
             else {

--- a/is.js
+++ b/is.js
@@ -344,7 +344,7 @@
         };
     }
 
-    function regexpCheckContextual(regexp) {
+    function regexpCheckContextual(regexp, regexps) {
         for(var regexpContext in regexps[regexp]) {
             if(regexps[regexp].hasOwnProperty(regexpContext)) {
                 if(is.undefined(is[regexpContext]) && regexpContext !== "default") {


### PR DESCRIPTION
Hi,

This is my first contribution on a project (and my first PR), so I hope I'm not wrong :/

I added the capability to use contextual regexp. For example, postalCode's check can be simply used by : 
```javascript
is.uk.postalCode('B184BJ');
```
Or
```javascript
is.fr.postalCode('44000');
```
, regarding the country code.

You can also use **always** and **default** regexp features. For example : 
```javascript
//Without context, affirmative uses the default regexp (true/yes) + the always regexp (1/okay)
is.affirmative(1);

//With context (french for exemple ^^), affirmative uses the fr regexp (vrai/oui) + the always regexp (1/okay)
is.all.fr.affirmative("okay", "oui");
```
These features are not limited to country code :)

I hope I am clear (regarding my english level...) and thx for this useful lib !