### PR TITLE
Fix AMD registration

### DIFF
--- a/is.js
+++ b/is.js
@@ -5,7 +5,7 @@
 ;(function(root, factory) {
     if(typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define(['is'], function(is) {
+        define(['is_js'], function(is) {
             // Also create a global in case some scripts
             // that are loaded still are looking for
             // a global even when an AMD loader is in use.


### PR DESCRIPTION
Fixes this error when using Webpack:

ERROR in ./~/is_js/is.js
Module not found: Error: Cannot resolve module 'is' in node_modules/is_js
 @ ./~/is_js/is.js 8:8-13:10