### PR TITLE
is.touchDevice()

### DIFF
--- a/is.js
+++ b/is.js
@@ -697,7 +697,7 @@
         is.touchDevice = function() {
             return(
               ('ontouchstart' in window) ||
-              ('DocumentTouch' in window. && document instanceof DocumentTouch)
+              ('DocumentTouch' in window && document instanceof DocumentTouch)
             );
         };
     }

--- a/is.js
+++ b/is.js
@@ -692,6 +692,14 @@
         is.offline = not(is.online);
         // offline method does not support 'all' and 'any' interfaces
         is.offline.api = ['not'];
+
+        // is a touch device ?
+        is.touchDevice = function() {
+            return(
+              ('ontouchstart' in window) ||
+              ('DocumentTouch' in window. && document instanceof DocumentTouch)
+            );
+        };
     }
 
     // Object checks


### PR DESCRIPTION
Browser/Vendor agnostic test if current device (in browser mode) is a
touch device (Phone, tablet, hybrid device in tablet mode, ...).
Useful to condition a Swipe instantiation, for exemple.