### PR TITLE
update blackberry check to work for Blackberry 10 devices

### DIFF
--- a/is.js
+++ b/is.js
@@ -625,7 +625,7 @@
 
         // is current device blackberry?
         is.blackberry = function() {
-            return /blackberry/i.test(userAgent);
+            return /blackberry/i.test(userAgent) || /BB10/i.test(userAgent);
         };
         // blackberry method does not support 'all' and 'any' interfaces
         is.blackberry.api = ['not'];


### PR DESCRIPTION
Fix for https://github.com/arasatasaygin/is.js/issues/82. It seems that the user agent string changed for Blackberry 10 to ```Mozilla/5.0 (BB10; <Device Model>) AppleWebKit/<WebKit Version> (KHTML, like Gecko) Version/<BB Version #> Mobile Safari/<WebKit Version>```

http://devblog.blackberry.com/2012/08/blackberry-10-user-agent-string/