### PR TITLE
simplfy is.space by using regex whitespace character and add more is.space tests

### DIFF
--- a/is.js
+++ b/is.js
@@ -205,14 +205,8 @@
     is.falsy = not(is.truthy);
 
     // is a given value space?
-    // horizantal tab: 9, line feed: 10, vertical tab: 11, form feed: 12, carriage return: 13, space: 32
     is.space =  function(value) {
-        if(is.char(value)) {
-            var characterCode = value.charCodeAt(0);
-            return (characterCode >  8 && characterCode < 14) || characterCode === 32;
-        } else {
-            return false;
-        }
+        return /^\s$/.test(value);
     };
 
     // Arithmetic checks

--- a/test/test.js
+++ b/test/test.js
@@ -784,6 +784,12 @@ describe("presence checks", function() {
         it("should return true if given value is space", function() {
             expect(is.space(' ')).to.be.true;
         });
+        it("should return false if given value is more than one space", function() {
+            expect(is.space('  ')).to.be.false;
+        });
+        it("should return true if given value is tab character", function() {
+            expect(is.space('\t')).to.be.true;
+        });
     });
     describe("is.not.space", function() {
         it("should return true if given value is not string", function() {
@@ -791,6 +797,9 @@ describe("presence checks", function() {
         });
         it("should return false if given value is space", function() {
             expect(is.not.space(' ')).to.be.false;
+        });
+        it("should return false if given value is tab character", function() {
+            expect(is.not.space('\t')).to.be.false;
         });
     });
     describe("is.all.space", function() {


### PR DESCRIPTION
Instead of trying to match character codes we should just check using regex. I added some tests to cover testing against the tabs instead of just testing against ```' '```.