### PR TITLE
add description, repository, bugs, and homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.7.2",
   "main": "is.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arasatasaygin/is.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/arasatasaygin/is.js/issues"
+  },
+  "homepage": "https://github.com/arasatasaygin/is.js",
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.10.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.2",
   "main": "is.js",
   "license": "MIT",
+  "description": "a general-purpose check library with no dependencies",
   "repository": {
     "type": "git",
     "url": "https://github.com/arasatasaygin/is.js.git"

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
-var expect = chai.expect;
+
+var expect = (typeof chai != 'undefined') ? chai.expect : require('chai').expect;
 
 describe("type checks", function() {
     describe("is.arguments", function() {


### PR DESCRIPTION
So https://www.npmjs.com/package/is_js shows information and links to the repo, issues page, and github page. 

Also, since there was no description, npm just uses the first line of the markdown which results in an undesirable search result on [npmjs.org](https://www.npmjs.com/search?q=is_js).
![screen shot 2015-03-10 at 10 34 05 pm](https://cloud.githubusercontent.com/assets/3527123/6589363/9d295ee4-c775-11e4-8404-80f2945168d3.png)