### PR TITLE
Add check to is.sorted for descending-ordered arrays. closes #97

### DIFF
--- a/is.js
+++ b/is.js
@@ -768,11 +768,39 @@
         if(is.not.array(arr)) {
             return false;
         }
-        for(var i = 0; i < arr.length; i++) {
-            if(arr[i] > arr[i + 1]) return false;
-        }
-        return true;
+
+        return checkArrayAsc(arr) || checkArrayDesc(arr);
     };
+
+    function checkArrayAsc(arr) {
+      for(var i = 0; i < arr.length; i++) {
+        var current = arr[i];
+        var next = arr[i + 1];
+
+        if(typeof next !== undefined) {
+          if(current > next) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    }
+
+    function checkArrayDesc(arr) {
+      for(var i = 0; i < arr.length; i++) {
+        var current = arr[i];
+        var next = arr[i + 1];
+
+        if(typeof next !== undefined) {
+          if(current < next) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    }
 
     // API
     // Set 'not', 'all' and 'any' interfaces to methods based on their api property

--- a/test/test.js
+++ b/test/test.js
@@ -3114,8 +3114,16 @@ describe("array checks", function() {
             var arr = [1, 2, 3, 4, 5];
             expect(is.sorted(arr)).to.be.true;
         });
+        it("should return true if given array is sorted", function() {
+            var arr = [5, 4, 3, 2, 1];
+            expect(is.sorted(arr)).to.be.true;
+        });
         it("should return false if given array is not sorted", function() {
             var arr = [1, 2, 3, 5, 4];
+            expect(is.sorted(arr)).to.be.false;
+        });
+        it("should return false if given array is not sorted", function() {
+            var arr = [5, 4, 3, 1, 2];
             expect(is.sorted(arr)).to.be.false;
         });
     });
@@ -3124,8 +3132,16 @@ describe("array checks", function() {
             var arr = [1, 2, 3, 4, 5];
             expect(is.not.sorted(arr)).to.be.false;
         });
+        it("should return false if given array is sorted", function() {
+            var arr = [5, 4, 3, 2, 1];
+            expect(is.not.sorted(arr)).to.be.false;
+        });
         it("should return true if given array is not sorted", function() {
             var arr = [1, 2, 3, 5, 4];
+            expect(is.not.sorted(arr)).to.be.true;
+        });
+        it("should return true if given array is not sorted", function() {
+            var arr = [5, 4, 3, 1, 2];
             expect(is.not.sorted(arr)).to.be.true;
         });
     });
@@ -3136,9 +3152,21 @@ describe("array checks", function() {
             expect(is.all.sorted(arr1, arr2)).to.be.true;
             expect(is.all.sorted([arr1, arr2])).to.be.true;
         });
+        it("should return true if all given arrays are sorted", function() {
+            var arr1 = [9, 8, 7, 6, 5];
+            var arr2 = [5, 4, 3, 2, 1];
+            expect(is.all.sorted(arr1, arr2)).to.be.true;
+            expect(is.all.sorted([arr1, arr2])).to.be.true;
+        });
         it("should return false if any given array is not sorted", function() {
             var arr1 = [1, 2, 3, 4, 5];
             var arr2 = [5, 6, 7, 9, 8];
+            expect(is.all.sorted(arr1, arr2)).to.be.false;
+            expect(is.all.sorted([arr1, arr2])).to.be.false;
+        });
+        it("should return false if any given array is not sorted", function() {
+          var arr1 = [9, 8, 7, 6, 5];
+          var arr2 = [5, 4, 3, 1, 2];
             expect(is.all.sorted(arr1, arr2)).to.be.false;
             expect(is.all.sorted([arr1, arr2])).to.be.false;
         });
@@ -3146,6 +3174,12 @@ describe("array checks", function() {
     describe("is.any.sorted", function() {
         it("should return true if any given array is sorted", function() {
             var arr1 = [1, 2, 3, 4, 5];
+            var arr2 = [10, 6, 7, 8, 9];
+            expect(is.any.sorted(arr1, arr2)).to.be.true;
+            expect(is.any.sorted([arr1, arr2])).to.be.true;
+        });
+        it("should return true if any given array is sorted", function() {
+            var arr1 = [5, 4, 3, 2, 1];
             var arr2 = [10, 6, 7, 8, 9];
             expect(is.any.sorted(arr1, arr2)).to.be.true;
             expect(is.any.sorted([arr1, arr2])).to.be.true;


### PR DESCRIPTION
There is probably a better implementation for this but this works until a better one can be put in place. 