### PR TITLE
Add Chrome version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1569,7 +1569,7 @@ is.not.ie();
 
 is.chrome(value:number)
 -----------
-####Checks if current browser is chrome.
+####Checks if current browser is chrome. Parameter is optional version number of browser.
 interface: not
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -1576,6 +1576,9 @@ interface: not
 is.chrome();
 => true if current browser is chrome
 
+is.chrome(41);
+=> true if chrome browser is v41
+
 is.not.chrome();
 => false if current browser is chrome
 ```

--- a/README.md
+++ b/README.md
@@ -1567,7 +1567,7 @@ is.not.ie();
 => false if current browser is ie
 ```
 
-is.chrome()
+is.chrome(value:number)
 -----------
 ####Checks if current browser is chrome.
 interface: not

--- a/is.js
+++ b/is.js
@@ -532,8 +532,18 @@
         var appVersion = 'navigator' in window && 'appVersion' in navigator && navigator.appVersion.toLowerCase() || '';
 
         // is current browser chrome?
-        is.chrome = function() {
-            return /chrome|chromium/i.test(userAgent) && /google inc/.test(vendor);
+        is.chrome = function(version) {            
+            var versionNumStart, versionNumEnd, versionNum, majorVersion;
+            if(!version) return /chrome|chromium/i.test(userAgent) && /google inc/.test(vendor);
+            else if(version) {
+                if(is.chrome()) {
+                    versionNumStart = userAgent.toLowerCase().indexOf("chrom");
+                    versionNumEnd = userAgent.indexOf(" ", versionNumStart);
+                    versionNum = userAgent.substring(versionNumStart, versionNumEnd).split("/")[1];
+                    majorVersion = versionNum.split(".")[0];
+                    return version === parseInt(majorVersion);
+                } else return false;
+            }
         };
         // chrome method does not support 'all' and 'any' interfaces
         is.chrome.api = ['not'];
@@ -551,7 +561,7 @@
             if(!version) {
                 return /msie/i.test(userAgent) || "ActiveXObject" in window;
             }
-            if(version >= 11) {
+            else if(version >= 11) {
                 return "ActiveXObject" in window;
             }
             return new RegExp('msie ' + version).test(userAgent);


### PR DESCRIPTION
Implemented version number checking for is.chrome() so the method now accepts a version parameter in the form of is.chrome(version). Updated the README before I saw your guidelines for contributing, sorry about that.