### PR TITLE
Split grunt in build and test tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,5 +17,6 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-mocha-phantomjs');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-jshint');
-    grunt.registerTask('default', ['uglify', 'jshint', 'mocha_phantomjs']);
+    grunt.registerTask('build', ['uglify', 'jshint', 'mocha_phantomjs']);
+    grunt.registerTask('test', ['mocha_phantomjs']);
 };


### PR DESCRIPTION
To make a bit easier to contribute and to add a good practice where we have the build task separated from the test task.