### PR TITLE
Adding is.webapp()

### DIFF
--- a/is.js
+++ b/is.js
@@ -602,6 +602,13 @@
         // ipod method does not support 'all' and 'any' interfaces
         is.ipod.api = ['not'];
 
+        // is site opened as a webapp?
+        is.webapp = function() {
+            return window.navigator.standalone;
+        };
+        // webapp method does not support 'all' and 'any' interfaces
+        is.webapp.api = ['not'];
+
         // is current device android?
         is.android = function() {
             return /android/i.test(userAgent);


### PR DESCRIPTION
Detects if website is running inside an iOS Web App. Supports 'not' interface.