### PR TITLE
Add is.vivaldi() check

### DIFF
--- a/is.js
+++ b/is.js
@@ -574,6 +574,25 @@
         // safari method does not support 'all' and 'any' interfaces
         is.safari.api = ['not'];
 
+        // is current browser vivaldi?
+        // parameter is optional
+        is.vivaldi = function(version) {
+            if (!version) { // null, undefined, empty, etc.
+                return /vivaldi/i.test(userAgent);
+            }
+            else {
+                if (is.vivaldi()) {
+                    return version === parseInt(userAgent.substring(userAgent.search(/vivaldi/i)).split(' ')[0].split('/')[1].split('.')[0]);
+                }
+                else {
+                    return false;
+                }
+            }
+
+        };
+        // vivaldi method does not support 'all' and 'any' interfaces
+        is.vivaldi.api = ['not'];
+
         // is current device ios?
         is.ios = function() {
             return is.iphone() || is.ipad() || is.ipod();

--- a/test/test.js
+++ b/test/test.js
@@ -1836,7 +1836,6 @@ describe("regexp checks", function() {
           });
     });
 });
-
 describe("string checks", function() {
     describe("is.include", function() {
         it("should return true if given string contains substring", function() {


### PR DESCRIPTION
Added a method to check if the browser is Vivaldi. The method takes one parameter which is optional.
The parameter is to check major version of the browser. There's also 'not' interface option too.

You can checkout Vivaldi here: https://vivaldi.com/ and the latest build's user agent string when this commit
was made here: http://user-agents.me/search?q=Vivaldi+1.0.162.4

Since this is an environment related addition, it's not possible to add tests.