### PR TITLE
Nested property for is.propertyDefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,13 @@ is.propertyDefined({yeap: 'yeap'}, 'nope');
 
 is.not.propertyDefined({}, 'nope');
 => true
+
+is.propertyDefined({nested:{property:'supported'}}, 'nested.property');
+=> true
+
+is.propertyDefined({nested:{property:'supported'}}, 'nested.not.supported');
+=> false
+
 ```
 
 is.windowObject(value:window)

--- a/is.js
+++ b/is.js
@@ -731,7 +731,22 @@
 
     // is given object has parameterized property?
     is.propertyDefined = function(obj, property) {
-        return is.object(obj) && is.string(property) && property in obj;
+        if (is.not.string(property) || is.not.object(obj)) {
+            return false;
+        }
+        if (property in obj) {
+            return true;
+        }
+        var parts = property.split('.'),
+            cursor = obj;
+        for (var i = 0; i < parts.length; i++) {
+            if (is.not.object(cursor) || !(parts[i] in cursor)) {
+                return false;
+            } else {
+                cursor = cursor[parts[i]];
+            }
+        }
+        return true;
     };
     // propertyDefined method does not support 'all' and 'any' interfaces
     is.propertyDefined.api = ['not'];

--- a/test/test.js
+++ b/test/test.js
@@ -2997,6 +2997,17 @@ describe("object checks", function() {
         });
     });
     describe("is.propertyDefined", function() {
+        it("should return false if given parameter is not an object", function() {
+           var array = [];
+            expect(is.propertyDefined(array, 'good')).to.be.false;
+        });
+        it("should return false if property is not a string", function() {
+           var obj = {
+               expected: 'expected',
+               result: 'result'
+           };
+            expect(is.propertyDefined(obj, obj)).to.be.false;
+        });
         it("should return true if given property is in objects", function() {
             var obj = {
                 test: 'test',
@@ -3011,6 +3022,22 @@ describe("object checks", function() {
                 is: 'is'
             };
             expect(is.propertyDefined(obj, 'good')).to.be.false;
+        });
+        it("should return true if given nested property is in objects", function() {
+           var obj = {
+               nested: {
+                   property:true
+               }
+           };
+           expect(is.propertyDefined(obj, 'nested.property')).to.be.true;
+        });
+        it("should return false if given nested property is not in objects", function() {
+            var obj = {
+                nested: {
+                    property:false
+                }
+            };
+            expect(is.propertyDefined(obj, 'nested.good')).to.be.false;
         });
     });
     describe("is.not.propertyDefined", function() {


### PR DESCRIPTION
I thought that it would be great to avoid to write things like:
```javascript
if (is.object(obj) && obj.nested && obj.nested.property && obj.nested.subproperty) {}
```
I prefer this syntax:
```javascript
if (is.propertyDefined(obj, 'nested.property.subproperty')) {}
```