### PR TITLE
MicroMessenger browser checking support

### DIFF
--- a/is.js
+++ b/is.js
@@ -574,6 +574,13 @@
         // safari method does not support 'all' and 'any' interfaces
         is.safari.api = ['not'];
 
+        // is current browser micromessenger?
+        is.micromessenger = function() {
+            return /micromessenger/i.test(userAgent);
+        };
+        // micromessenger method does not support 'all' and 'any' interfaces
+        is.micromessenger.api = ['not'];
+
         // is current device ios?
         is.ios = function() {
             return is.iphone() || is.ipad() || is.ipod();


### PR DESCRIPTION
MicroMessenger(WeChat) is a mostly used mobile app in China and East Asia. Developer often need to check the browser is a MicroMessenger(WeChat) or not.

Here is a sample user-agent,
`mozilla/5.0 (iphone; cpu iphone os 9_2 like mac os x) applewebkit/601.1.46 (khtml, like gecko) mobile/13c75 micromessenger/6.3.9 nettype/wifi language/zh_cn`

and a devise detect http://devicedetector.net/?ua=mozilla%2F5.0+%28iphone%3B+cpu+iphone+os+9_2+like+mac+os+x%29+applewebkit%2F601.1.46+%28khtml%2C+like+gecko%29+mobile%2F13c75+micromessenger%2F6.3.9+nettype%2Fwifi+language%2Fzh_cn

This PR support MicroMessenger checking by
```js
is.micromessenger();
is.not.micromessenger();
```