### PR TITLE
Modify wording to avoid highlight "error"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1899,7 +1899,7 @@ is.touchDevice();
 => true if current device supports touch
 
 is.not.touchDevice();
-=> true if current device doesn't support touch
+=> true if current device does not support touch
 ```
 
 Time checks


### PR DESCRIPTION
This will prevent the following highlight "error":

> ![is](https://cloud.githubusercontent.com/assets/1921409/15088450/59f5b6ac-13ca-11e6-8ae2-4bc7212c7555.png)