### PR TITLE
Update `is.number` and `is.finite` methods

### DIFF
--- a/is.js
+++ b/is.js
@@ -276,8 +276,8 @@
     };
 
     // is a given number finite?
-    is.finite = isFinite || function(n) {
-        return is.not.infinite(n) && is.not.nan(n);
+    is.finite = Number.isFinite || function(n) {
+        return is.number(n);
     };
 
     // is a given number infinite?

--- a/is.js
+++ b/is.js
@@ -163,7 +163,7 @@
 
     // is a given value number?
     is.number = function(value) {
-        return is.not.nan(value) && toString.call(value) === '[object Number]';
+        return is.not.nan(value) && is.not.infinite(value) && toString.call(value) === '[object Number]';
     };
 
     // is a given value object?

--- a/test/test.js
+++ b/test/test.js
@@ -122,9 +122,16 @@
                 var notNumber = 'test';
                 expect(is.number(notNumber)).to.be.false;
             });
+            it('should return false if passed parameter type is a numeric string', function() {
+                var numericString = '1';
+                expect(is.number(numericString)).to.be.false;
+            });
             it('should return false if passed parameter is NaN', function() {
                 expect(is.number(NaN)).to.be.false;
-            })
+            });
+            it('should return false if passed parameter is Infinity', function() {
+                expect(is.number(Infinity)).to.be.false;
+            });
         });
         checkApi('number');
 


### PR DESCRIPTION
While implementing #267 I realised that to be consistent I needed to update `is.finite` and `is.number`.

- `is.number` now considers infinite values as non numeric.

- `is.finite` now returns `Number.isFinite` if available or performs an `is.number` check —implementations are equivalent.

*Please, let me know if this is okay or I should only update the implementation of `is.finite`.*

---

**This is a breaking change** and would require a major version bump.

Resolves #267.