### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1600,7 +1600,7 @@ is.all.sorted([[1, 2], [5, 4]]);
 
 Environment checks
 ==================
-####Environment checks are not available as node module.
+#### Environment checks are not available as node module.
 
 is.ie(range:number|string)
 -------------------


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
