### PR TITLE
Improve safari user-agent detection

### DIFF
--- a/is.js
+++ b/is.js
@@ -765,7 +765,7 @@
     // is current browser safari?
     // parameter is optional
     is.safari = function(range) {
-        var match = userAgent.match(/version\/(\d+).+?safari/);
+        var match = userAgent.match(/version\/(\d+)((?!chrome).)+?safari/);
         return match !== null && compareVersion(match[1], range);
     };
     // safari method does not support 'all' and 'any' interfaces

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is_js",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "is.js",
   "license": "MIT",
   "description": "micro check library",


### PR DESCRIPTION
`is.safari()` returns true for Facebook inapp browser because the user-agent may contain safari and chrome at the same time.
Return true only if the user-agent contains safari but not chrome.
fixes: #296