### PR TITLE
docs: Fix simple typo, enviroments -> environments

### DIFF
--- a/is.js
+++ b/is.js
@@ -15,7 +15,7 @@
         });
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like enviroments that support module.exports,
+        // only CommonJS-like environments that support module.exports,
         // like Node.
         module.exports = factory();
     } else {


### PR DESCRIPTION
There is a small typo in is.js.

Should read `environments` rather than `enviroments`.

