### PR TITLE
ipad/ios13+ detection

### DIFF
--- a/is.js
+++ b/is.js
@@ -676,7 +676,15 @@
     // is current device ipad?
     // parameter is optional
     is.ipad = function(range) {
-        var match = userAgent.match(/ipad.+?os (\d+)/);
+
+        // with ios 13+ support
+        var match = is.not.iphone() && is.not.ipod() 
+                  ? ( userAgent.match(/ipad.+?os (\d+)/) || ( ( userAgent.includes("mac") && "ontouchend" in document ) 
+                    ? userAgent.match(/version\/(\d+)/) 
+                    : null ) )
+                  : null;
+
+        // var match = userAgent.match(/ipad.+?os (\d+)/);
         return match !== null && compareVersion(match[1], range);
     };
     // ipad method does not support 'all' and 'any' interfaces


### PR DESCRIPTION
Since the user agent string for iPads changed in iOS 13, the current function returned false. I updated the existing function to now detect iPads' new user agent string, with correct version number detection, as well. 