### PR TITLE
Correct check if is edge

### DIFF
--- a/is.js
+++ b/is.js
@@ -642,7 +642,7 @@
     // is current browser edge?
     // parameter is optional
     is.edge = function(range) {
-        var match = userAgent.match(/edge\/(\d+)/);
+        var match = userAgent.match(/edge?\/(\d+)/);
         return match !== null && compareVersion(match[1], range);
     };
     // edge method does not support 'all' and 'any' interfaces


### PR DESCRIPTION
For Example navigator.userAgent return 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36 Edg/97.0.1072.55' Edg without e on the end